### PR TITLE
Don't scroll refine panel when it's closed closes #46

### DIFF
--- a/src/components/RefinePanel.vue
+++ b/src/components/RefinePanel.vue
@@ -17,21 +17,6 @@
             class="hide-for-small-only"
             @click.native="clearAll"
           />
-          <!-- <a href="#"
-            @click="clearAll"
-            class="clear-all hide-for-small-only">Clear all</a> -->
-
-          <!-- <div class="legend-title h3 margin-add">Address:</div>
-          <div class="margin-add min-width-needed">{{ addressEntered }}</div>
-          <a href="#"
-            @click="clearAddress"
-            class="test">Clear address</a>
-
-          <div class="legend-title h3 margin-add">Keywords:</div>
-          <div class="margin-add min-width-needed">{{ keywordsEntered }}</div>
-          <a href="#"
-            @click="clearKeywords"
-            class="test">Clear Keywords</a> -->
         </div>
         <div
           v-if="dataStatus === 'success'"
@@ -63,7 +48,7 @@
           </PhilaButton>
           <PhilaButton
             button-text="Clear all"
-            @click.native="clearAll"
+            @click.native="closeRefinePanel"
           />
         </div>
       </fieldset>
@@ -131,14 +116,6 @@ export default {
     // this.$data.selected = this.$store.state.selectedServices;
   },
   methods: {
-    clearAddress() {
-      if (this.$store.state.geocode.status === 'success') {
-        this.$controller.dataManager.resetGeocode();
-      }
-    },
-    clearKeywords() {
-      this.$store.commit('setSelectedKeywords', '');
-    },
     clearAll() {
       console.log('RefinePanel clearAll is running');
       if (this.selected.length) {
@@ -176,6 +153,11 @@ export default {
         this.refineOpen = !this.refineOpen;
       }
     },
+    closeRefinePanel(){
+      this.scrollToTop();
+      this.expandRefine();
+      this.clearAll();
+    },
   },
 };
 </script>
@@ -184,7 +166,7 @@ export default {
 $refine-panel-height: 19vh;
 .refine-panel{
   max-height: $refine-panel-height;
-  overflow-y: scroll;
+  overflow-y: hidden;
   padding: 1rem;
 
   .refine-title{
@@ -257,6 +239,7 @@ $refine-panel-height: 19vh;
     }
   }
   &.refine-open{
+    overflow-y: scroll;
     height: calc(100vh - 100px);
     max-height: 100vh;
     z-index: 1002;


### PR DESCRIPTION
Refine panel mobile "Clear all" button collapses panel and scrolls to top.